### PR TITLE
[Feat] #31 일정 상세 화면에서 캘린더에 추가 버튼을 누르면 캘린더 쓰기 권한을 요청하고, 허용 시 캘린더에 추가되는 기능 구현

### DIFF
--- a/EventLogger/App/Dependencies.swift
+++ b/EventLogger/App/Dependencies.swift
@@ -20,6 +20,16 @@ extension DependencyValues {
         get { self[SwiftDataManagerKey.self] }
         set { self[SwiftDataManagerKey.self] = newValue }
     }
+    
+    var calendarService: CalendarServicing {
+        get { self[CalendarServiceKey.self] }
+        set { self[CalendarServiceKey.self] = newValue }
+    }
+    
+    var settingsService: SettingsServicing {
+        get { self[SettingsServiceKey.self] }
+        set { self[SettingsServiceKey.self] = newValue }
+    }
 }
 
 // MARK: ModelContext
@@ -44,6 +54,18 @@ private enum SwiftDataManagerKey: DependencyKey {
     static var testValue: SwiftDataManager {
         SwiftDataManager()
     }
+}
+
+// MARK: Calendar Service
+private enum CalendarServiceKey: DependencyKey {
+    static var liveValue: CalendarServicing = CalendarService()
+    static var testValue: CalendarServicing = CalendarService() // 테스트용 만들 필요
+}
+
+// MARK: Settings Service
+private enum SettingsServiceKey: DependencyKey {
+    static var liveValue: SettingsServicing = SettingsService()
+    static var testValue: SettingsServicing = SettingsService() // 테스트용 만들 필요
 }
 
 extension ModelContext: @unchecked @retroactive Sendable {}

--- a/EventLogger/Resources/Info.plist
+++ b/EventLogger/Resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+	<string>이 앱은 이벤트를 캘린더에 추가하기 위해 권한이 필요합니다.</string>
 	<key>UIUserInterfaceStyle</key>
 	<string>Dark</string>
 	<key>UIApplicationSceneManifest</key>

--- a/EventLogger/Scenes/EventDetail/EventDetailReactor.swift
+++ b/EventLogger/Scenes/EventDetail/EventDetailReactor.swift
@@ -13,9 +13,18 @@ import RxFlow
 import RxRelay
 import RxSwift
 
+// 결과를 VC에서 알럿으로 보여주기 위한 단발 이벤트
+enum CalendarSaveOutcome {
+    case success
+    case denied
+    case failure(message: String)
+}
+
 final class EventDetailReactor: BaseReactor {
     // 사용자 액션 정의 (사용자의 의도)
-    enum Action {}
+    enum Action {
+        case addToCalendarTapped
+    }
 
     // 상태변경 이벤트 정의 (상태를 어떻게 바꿀 것인가)
     enum Mutation {}
@@ -27,7 +36,15 @@ final class EventDetailReactor: BaseReactor {
 
     // 생성자에서 초기 상태 설정
     let initialState: State
+    
+    // 외부로 노출할 단발 이벤트 스트림
+    let saveOutcome = PublishRelay<CalendarSaveOutcome>()
+    
+    // DI
+    @Dependency(\.calendarService) private var calendarService
 
+    private let disposeBag = DisposeBag()
+    
     init(eventItem: EventItem) {
         initialState = State(eventItem: eventItem)
     }
@@ -35,7 +52,30 @@ final class EventDetailReactor: BaseReactor {
     // Action이 들어왔을 때 어떤 Mutation으로 바뀔지 정의
     // 사용자 입력 → 상태 변화 신호로 변환
     func mutate(action: Action) -> Observable<Mutation> {
-        switch action {}
+        switch action {
+        case .addToCalendarTapped:
+            // 권한 요청 -> 저장 -> 결과 알림
+            let item = currentState.eventItem
+            calendarService.requestAccess()
+                .flatMap { [calendarService] granted -> Single<Void> in
+                    if granted {
+                        return calendarService.save(eventItem: item)
+                    } else {
+                        // 접근 거부
+                        self.saveOutcome.accept(.denied)
+                        return .never()
+                    }
+                }
+                .subscribe(
+                    onSuccess: { [weak self] in self?.saveOutcome.accept(.success) },
+                    onFailure: { [weak self] error in
+                        self?.saveOutcome.accept(.failure(message: error.localizedDescription))
+                    }
+                )
+                .disposed(by: disposeBag)
+            
+            return .empty()
+        }
     }
 
     // Mutation이 발생했을 때 상태(State)를 실제로 바꿈

--- a/EventLogger/Scenes/EventDetail/EventDetailViewController.swift
+++ b/EventLogger/Scenes/EventDetail/EventDetailViewController.swift
@@ -99,16 +99,50 @@ class EventDetailViewController: BaseViewController<EventDetailReactor> {
         infoItemView.configureView(eventItem: eventItem)
         memoView.configureView(eventItem.memo)
 
-        // TODO: 버튼액션
         infoItemView.addCalendarButton.rx.tap
-            .bind {
-                print("Add Calendar")
-            }
+            .map { EventDetailReactor.Action.addToCalendarTapped }
+            .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
+        // TODO: 버튼액션
         infoItemView.findDirectionsButton.rx.tap
             .bind {
                 print("Find Way")
+            }
+            .disposed(by: disposeBag)
+        
+        // 저장 결과 알럿
+        reactor.saveOutcome
+            .observe(on: MainScheduler.instance)
+            .bind(with: self) { owner, outcome in
+                let alert: UIAlertController
+                switch outcome {
+                case .success:
+                    alert = UIAlertController(
+                        title: "캘린더 저장 완료",
+                        message: "이 이벤트가 캘린더에 저장되었습니다.",
+                        preferredStyle: .alert
+                    )
+                case .denied:
+                    alert = UIAlertController(
+                        title: "접근 권한 필요",
+                        message: "설정 > 개인정보보호 > 캘린더에서 권한을 허용해주세요.",
+                        preferredStyle: .alert
+                    )
+                    alert.addAction(UIAlertAction(title: "설정으로 이동", style: .default) { _ in
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            UIApplication.shared.open(url)
+                        }
+                    })
+                case .failure(let message):
+                    alert = UIAlertController(
+                        title: "저장 실패",
+                        message: "캘린더 저장 중 오류가 발생했습니다.\n\(message)",
+                        preferredStyle: .alert
+                    )
+                }
+                alert.addAction(UIAlertAction(title: "확인", style: .default))
+                owner.present(alert, animated: true)
             }
             .disposed(by: disposeBag)
     }

--- a/EventLogger/Util/CalendarService.swift
+++ b/EventLogger/Util/CalendarService.swift
@@ -1,0 +1,90 @@
+//
+//  CalendarService.swift
+//  EventLogger
+//
+//  Created by 김우성 on 8/31/25.
+//
+
+import EventKit
+import Foundation
+import RxSwift
+
+// MARK: 인터페이스
+protocol CalendarServicing {
+    /// 캘린더 접근 권한 요청 (결정된 상태라면 즉시 리턴)
+    func requestAccess() -> Single<Bool>
+    /// EventItem을 기본 캘린더에 저장
+    func save(eventItem: EventItem) -> Single<Void>
+}
+
+// MARK: 구현
+final class CalendarService: CalendarServicing {
+    private let store = EKEventStore()
+    
+    // 권한 요청
+    func requestAccess() -> Single<Bool> {
+        return Single<Bool>.create { single in
+            let status = EKEventStore.authorizationStatus(for: .event)
+            switch status {
+            case .fullAccess:
+                // 읽기/쓰기 모두 가능
+                single(.success(true))
+                
+            case .writeOnly:
+                // "쓰기 전용" 권한. 이벤트 저장에는 충분하지만
+                // 읽기가 필요한 기능이 있다면 false를 반환하도록 정책 변경 필요
+                single(.success(true))
+                
+            case .denied, .restricted:
+                single(.success(false))
+                
+            case .notDetermined:
+                Task {
+                    do {
+                        // 최소권한: 쓰기 권한만 요청
+                        let granted = try await self.store.requestWriteOnlyAccessToEvents()
+                        single(.success(granted))
+                    } catch {
+                        single(.failure(error))
+                    }
+                }
+                
+            @unknown default:
+                single(.success(false))
+            }
+            return Disposables.create()
+        }
+    }
+    
+    func save(eventItem: EventItem) -> Single<Void> {
+        return Single.create { [store] single in
+            // 캘린더(기본 캘린더)에 이벤트 생성
+            let event = EKEvent(eventStore: store)
+            event.calendar = store.defaultCalendarForNewEvents
+            
+            event.title = eventItem.title
+            event.startDate = eventItem.startTime
+            event.endDate = eventItem.endTime
+            event.location = eventItem.location
+            event.notes = eventItem.memo
+            
+            // 이미지/아티스트/통화 등은 EventKit에 직접 매핑할 필드가 없으므로 메모에 보조정보를 남기는 식으로
+            if !eventItem.artists.isEmpty {
+                let artistsLine = "\n\n[출연자] " + eventItem.artists.joined(separator: ", ")
+                event.notes = (event.notes ?? "") + artistsLine
+            }
+            if eventItem.expense > 0 {
+                let expenseLine = "\n[비용] \(eventItem.currency.rawValue) \(eventItem.expense)"
+                event.notes = (event.notes ?? "") + expenseLine
+            }
+            
+            do {
+                try store.save(event, span: .thisEvent, commit: true)
+                single(.success(()))
+            } catch {
+                single(.failure(error))
+            }
+            return Disposables.create()
+        }
+    }
+}

--- a/EventLogger/Util/SettingsService.swift
+++ b/EventLogger/Util/SettingsService.swift
@@ -1,0 +1,58 @@
+//
+//  SettingsService.swift
+//  EventLogger
+//
+//  Created by 김우성 on 9/1/25.
+//
+
+import Foundation
+
+protocol SettingsServicing {
+    var autoSaveToCalendar: Bool { get set }
+}
+
+struct SettingsService: SettingsServicing {
+    private let defaults: UserDefaults
+    private let autoSaveKey = "settings.autoSaveToCalendar"
+    
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        // 기본값이 없을 경우 false로 초기화
+        if defaults.object(forKey: autoSaveKey) == nil {
+            defaults.set(false, forKey: autoSaveKey)
+        }
+    }
+    
+    var autoSaveToCalendar: Bool {
+        get { defaults.bool(forKey: autoSaveKey) }
+        set { defaults.set(newValue, forKey: autoSaveKey) }
+    }
+}
+
+/*
+ // 설정 화면에서 스위치 어떻게 하면 되나
+ final class SettingsViewController: UIViewController {
+     private let toggle = UISwitch()
+     @Dependency(\.settingsService) private var settingsService
+
+     override func viewDidLoad() {
+         super.viewDidLoad()
+         view.backgroundColor = .systemBackground
+         navigationItem.title = "설정"
+
+         toggle.isOn = settingsService.autoSaveToCalendar
+         toggle.addTarget(self, action: #selector(onToggleChanged), for: .valueChanged)
+
+         view.addSubview(toggle)
+         toggle.translatesAutoresizingMaskIntoConstraints = false
+         NSLayoutConstraint.activate([
+             toggle.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+             toggle.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+         ])
+     }
+
+     @objc private func onToggleChanged() {
+         settingsService.autoSaveToCalendar = toggle.isOn
+     }
+ }
+ */


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #31 일정 상세 화면에서 캘린더에 추가 버튼을 누르면 캘린더 쓰기 권한을 요청하고, 허용 시 캘린더에 추가되는 기능 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #31 

<br>

### 🦁 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->
- 일정 상세 화면에서 캘린더에 추가 버튼을 누르면 캘린더 쓰기 권한을 요청하고, 허용 시 캘린더에 추가되는 기능 구현
  - Dependencies에 DI 키 추가 (calendarService, settingsService)
  - CalendarService는 기본 캘린더에 EKEvent 생성함
  - SettingsService는 캘린더에 자동저장함
  - EventDetailReactor에 .addToCalendarTapped 액션 추가 (캘린더 권한/저장, 알림용 이벤트 saveOutcome 방출
  - EventDetailViewController에 버튼 바인딩 Reactor 액션으로. 메인 스레드 보장용 .observe(on: )
  - ScheduleReactor에서 autoSaveToCalendarIfNeeded() 호출 - 성공/실패 결과 알림 없음

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->

https://github.com/user-attachments/assets/4bedda27-6b8e-4775-afc3-95f5a7e0681a


<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->
- 수정 모드에서 수정 시 기존 EKEvent 갱신 필요할지 논의 필요 (쓰기 권한만이 아니라 전체 액세스 권한 필요)

<br>
