### PR TITLE
[Feat] #40 이벤트 리스트 뷰에 최신 디자인과 기능 반영

### DIFF
--- a/EventLogger/Extensions/UIButton++Configuration.swift
+++ b/EventLogger/Extensions/UIButton++Configuration.swift
@@ -8,7 +8,7 @@ extension UIButton {
         var config = UIButton.Configuration.bordered()
         config.contentInsets = .init(top: 2, leading: 8, bottom: 2, trailing: 8)
         config.background.cornerRadius = 6
-        config.baseForegroundColor = .white
+        config.baseForegroundColor = .neutral50
         config.background.backgroundColor = .systemGray3
         config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
             var outgoing = incoming
@@ -19,7 +19,7 @@ extension UIButton {
         button.configurationUpdateHandler = { button in
             var config = button.configuration ?? .bordered()
             let isOn = button.isSelected
-            config.baseForegroundColor = isOn ? .primary500 : .white
+            config.baseForegroundColor = isOn ? .primary500 : .neutral50
             button.configuration = config
         }
         return button

--- a/EventLogger/Extensions/UIImage++SymbolConfiguration.swift
+++ b/EventLogger/Extensions/UIImage++SymbolConfiguration.swift
@@ -24,7 +24,7 @@ extension UIImage {
     static func symbolDefault(
         named name: String,
         config: UIImage.SymbolConfiguration,
-        color: UIColor = .white // TODO: App Primary
+        color: UIColor = .neutral50 // TODO: App Primary
     ) -> UIImage? {
         return UIImage(systemName: name)?
             .withConfiguration(config)

--- a/EventLogger/Scenes/EventDetail/EventDetailViewController.swift
+++ b/EventLogger/Scenes/EventDetail/EventDetailViewController.swift
@@ -23,7 +23,7 @@ class EventDetailViewController: BaseViewController<EventDetailReactor> {
         target: nil,
         action: nil
     ).then {
-        $0.tintColor = .white
+        $0.tintColor = .neutral50
     }
 
     private let scrollView = UIScrollView()

--- a/EventLogger/Scenes/EventList/Control/PillSegmentedControl.swift
+++ b/EventLogger/Scenes/EventList/Control/PillSegmentedControl.swift
@@ -11,12 +11,10 @@ import UIKit
 public final class PillSegmentedControl: UIControl {
     // MARK: - Public API
 
-    /// 표시할 항목 텍스트 배열
     public var items: [String] {
         didSet { rebuildButtons() }
     }
 
-    /// 현재 선택된 인덱스
     public private(set) var selectedIndex: Int = 0 {
         didSet {
             if !isSettingUp {
@@ -26,13 +24,11 @@ public final class PillSegmentedControl: UIControl {
         }
     }
 
-    /// 외부에서 UISegmentedControl처럼 접근할 수 있도록 유지 (Rx 확장에서 사용)
     public var selectedSegmentIndex: Int {
         get { selectedIndex }
         set { setSelectedIndex(newValue, animated: false) }
     }
 
-    /// 바깥 알약 컨테이너 안쪽 여백
     public var contentInsets: NSDirectionalEdgeInsets = .init(top: 6, leading: 6, bottom: 6, trailing: 6) {
         didSet {
             stackTop?.constant = contentInsets.top
@@ -43,7 +39,6 @@ public final class PillSegmentedControl: UIControl {
         }
     }
 
-    /// 세그먼트 간 간격
     public var segmentSpacing: CGFloat = 6 {
         didSet {
             stackView.spacing = segmentSpacing
@@ -51,58 +46,77 @@ public final class PillSegmentedControl: UIControl {
         }
     }
 
-    /// 선택 캡슐 배경색
     public var capsuleBackgroundColor: UIColor = .systemBlue {
         didSet { selectionCapsuleView.backgroundColor = capsuleBackgroundColor }
     }
 
-    /// 선택 캡슐 외곽선 색
     public var capsuleBorderColor: UIColor = .systemBlue {
         didSet { selectionCapsuleView.layer.borderColor = capsuleBorderColor.cgColor }
     }
 
-    /// 선택 캡슐 외곽선 두께
     public var capsuleBorderWidth: CGFloat = 0 {
         didSet { selectionCapsuleView.layer.borderWidth = capsuleBorderWidth }
     }
     
-    /// 선택 캡슐 섀도우 속성
-    public var capsuleShadowColor: UIColor = .primary500 {
+    public var capsuleShadowColor: UIColor = .white {
         didSet { selectionCapsuleView.layer.shadowColor = capsuleShadowColor.cgColor }
     }
+
     public var capsuleShadowOpacity: Float = 1.0 {
         didSet { selectionCapsuleView.layer.shadowOpacity = capsuleShadowOpacity }
     }
+
     public var capsuleShadowRadius: CGFloat = 6 {
         didSet { selectionCapsuleView.layer.shadowRadius = capsuleShadowRadius }
     }
+
     public var capsuleShadowOffset: CGSize = .zero {
         didSet { selectionCapsuleView.layer.shadowOffset = capsuleShadowOffset }
     }
 
-    /// 외곽선 색
     public var borderColor: UIColor = UIColor.systemBlue.withAlphaComponent(0.6) {
         didSet { layer.borderColor = borderColor.cgColor }
     }
 
-    /// 외곽선 두께
     public var borderWidth: CGFloat = 1.5 {
         didSet { layer.borderWidth = borderWidth }
     }
 
-    /// 비선택 텍스트 색
     public var normalTextColor: UIColor = .systemBlue {
         didSet { buttons.forEach { $0.setNeedsUpdateConfiguration() } }
     }
 
-    /// 선택 텍스트 색
     public var selectedTextColor: UIColor = .white {
         didSet { buttons.forEach { $0.setNeedsUpdateConfiguration() } }
     }
 
-    /// 폰트
-    public var font: UIFont = .systemFont(ofSize: 15, weight: .medium) {
+    public var normalFont: UIFont = .systemFont(ofSize: 15, weight: .regular) {
         didSet { buttons.forEach { $0.setNeedsUpdateConfiguration() } }
+    }
+
+    public var selectedFont: UIFont = .systemFont(ofSize: 15, weight: .semibold) {
+        didSet { buttons.forEach { $0.setNeedsUpdateConfiguration() } }
+    }
+
+    // 텍스트 섀도우 속성 (CALayer 기반)
+    public var normalTextShadowColor: UIColor? {
+        didSet { updateAllLabelShadows() }
+    }
+
+    public var selectedTextShadowColor: UIColor? {
+        didSet { updateAllLabelShadows() }
+    }
+
+    public var textShadowOpacity: Float = 0.6 {
+        didSet { updateAllLabelShadows() }
+    }
+
+    public var textShadowRadius: CGFloat = 2 {
+        didSet { updateAllLabelShadows() }
+    }
+
+    public var textShadowOffset: CGSize = .init(width: 1, height: 1) {
+        didSet { updateAllLabelShadows() }
     }
 
     // MARK: - Subviews
@@ -149,16 +163,13 @@ public final class PillSegmentedControl: UIControl {
     private func configureOnce() {
         backgroundColor = .clear
 
-        // 외곽 알약 스타일
         layer.masksToBounds = false
         layer.borderWidth = borderWidth
         layer.borderColor = borderColor.cgColor
-        
-        // 선택 캡슐
+
         selectionCapsuleView.backgroundColor = capsuleBackgroundColor
         selectionCapsuleView.layer.borderColor = capsuleBorderColor.cgColor
         selectionCapsuleView.layer.borderWidth = capsuleBorderWidth
-        // 섀도우 기본값
         selectionCapsuleView.layer.shadowColor = capsuleShadowColor.cgColor
         selectionCapsuleView.layer.shadowOpacity = capsuleShadowOpacity
         selectionCapsuleView.layer.shadowRadius = capsuleShadowRadius
@@ -167,7 +178,6 @@ public final class PillSegmentedControl: UIControl {
         selectionCapsuleView.isUserInteractionEnabled = false
         selectionCapsuleView.translatesAutoresizingMaskIntoConstraints = false
 
-        // 스택
         stackView.axis = .horizontal
         stackView.alignment = .fill
         stackView.distribution = .fillEqually
@@ -205,18 +215,27 @@ public final class PillSegmentedControl: UIControl {
             var configuration = UIButton.Configuration.plain()
             configuration.contentInsets = .init(top: 6, leading: 12, bottom: 6, trailing: 12)
             configuration.background.backgroundColor = .clear
-            configuration.attributedTitle = AttributedString(title, attributes: .init([.font: font]))
-            configuration.baseForegroundColor = (index == selectedIndex) ? selectedTextColor : normalTextColor
+
+            let isSelected = (index == selectedIndex)
+            configuration.attributedTitle = makeAttributedTitle(text: title, isSelected: isSelected)
+            configuration.baseForegroundColor = isSelected ? selectedTextColor : normalTextColor
             button.configuration = configuration
 
             button.configurationUpdateHandler = { [weak self] button in
                 guard let self = self,
                       let buttonIndex = self.buttons.firstIndex(of: button) else { return }
+
+                let isSelected = (buttonIndex == self.selectedIndex)
                 var updated = button.configuration ?? .plain()
-                updated.attributedTitle = AttributedString(self.items[buttonIndex], attributes: .init([.font: self.font]))
-                updated.baseForegroundColor = (buttonIndex == self.selectedIndex) ? self.selectedTextColor : self.normalTextColor
+                updated.attributedTitle = self.makeAttributedTitle(text: self.items[buttonIndex], isSelected: isSelected)
+                updated.baseForegroundColor = isSelected ? self.selectedTextColor : self.normalTextColor
                 updated.background.backgroundColor = .clear
                 button.configuration = updated
+
+                // titleLabel 섀도우 적용
+                if let label = button.titleLabel {
+                    self.applyTextLayerShadow(to: label, isSelected: isSelected)
+                }
             }
 
             button.addAction(UIAction { [weak self] _ in
@@ -278,14 +297,12 @@ public final class PillSegmentedControl: UIControl {
 
     // MARK: - Layout
 
-    public override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
 
-        // 원형률은 고정 16으로 통일 (상단/하단에서 중복 세팅 제거)
         layer.cornerRadius = 16
         selectionCapsuleView.layer.cornerRadius = 16
 
-        // shadowPath를 현재 캡슐 프레임에 맞게 갱신
         let path = UIBezierPath(roundedRect: selectionCapsuleView.bounds, cornerRadius: 16).cgPath
         selectionCapsuleView.layer.shadowPath = path
 
@@ -295,7 +312,7 @@ public final class PillSegmentedControl: UIControl {
         }
     }
 
-    public override var intrinsicContentSize: CGSize {
+    override public var intrinsicContentSize: CGSize {
         let buttonHeights = buttons.map { $0.intrinsicContentSize.height }
         let height = (buttonHeights.max() ?? 28) + contentInsets.top + contentInsets.bottom
         let totalButtonsWidth = buttons.reduce(0) { $0 + $1.intrinsicContentSize.width }
@@ -324,10 +341,29 @@ public final class PillSegmentedControl: UIControl {
         invalidateIntrinsicContentSize()
     }
 
-    private func animateStackFade() {
-        stackView.alpha = 0
-        UIView.animate(withDuration: 0.18) {
-            self.stackView.alpha = 1
+    // MARK: - Helpers
+
+    private func makeAttributedTitle(text: String, isSelected: Bool) -> AttributedString {
+        let font = isSelected ? selectedFont : normalFont
+        let ns = NSMutableAttributedString(string: text, attributes: [.font: font])
+        return AttributedString(ns)
+    }
+
+    private func applyTextLayerShadow(to label: UILabel, isSelected: Bool) {
+        label.layer.masksToBounds = false
+        label.layer.shadowColor = (isSelected ? selectedTextShadowColor?.cgColor : normalTextShadowColor?.cgColor)
+        label.layer.shadowOpacity = textShadowOpacity
+        label.layer.shadowRadius = textShadowRadius
+        label.layer.shadowOffset = textShadowOffset
+        label.layer.shouldRasterize = true
+        label.layer.rasterizationScale = UIScreen.main.scale
+    }
+
+    private func updateAllLabelShadows() {
+        for (i, button) in buttons.enumerated() {
+            if let label = button.titleLabel {
+                applyTextLayerShadow(to: label, isSelected: i == selectedIndex)
+            }
         }
     }
 }

--- a/EventLogger/Scenes/EventList/Control/PillSegmentedControl.swift
+++ b/EventLogger/Scenes/EventList/Control/PillSegmentedControl.swift
@@ -57,7 +57,7 @@ public final class PillSegmentedControl: UIControl {
     public var capsuleBorderWidth: CGFloat = 0 {
         didSet { selectionCapsuleView.layer.borderWidth = capsuleBorderWidth }
     }
-    
+
     public var capsuleShadowColor: UIColor = .white {
         didSet { selectionCapsuleView.layer.shadowColor = capsuleShadowColor.cgColor }
     }

--- a/EventLogger/Scenes/EventList/EventListReactor.swift
+++ b/EventLogger/Scenes/EventList/EventListReactor.swift
@@ -71,11 +71,10 @@ final class EventListReactor: BaseReactor {
         case .reloadCategories:
             let categoryItems = swiftDataManager.fetchAllCategories()
             return .just(.setCategories(categoryItems))
-            
+
         case let .setYearFilter(year):
             return .just(.setYearFilter(year))
         }
-        
     }
 
     // Mutation이 발생했을 때 상태(State)를 실제로 바꿈
@@ -94,7 +93,7 @@ final class EventListReactor: BaseReactor {
 
         case let .setCategories(categories):
             newState.categories = categories
-            
+
         case let .setYearFilter(year):
             newState.yearFilter = year
         }

--- a/EventLogger/Scenes/EventList/EventListReactor.swift
+++ b/EventLogger/Scenes/EventList/EventListReactor.swift
@@ -19,7 +19,8 @@ final class EventListReactor: BaseReactor {
         case reloadEventItems
         case reloadCategories
         case setFilter(EventListFilter)
-        case toggleSort
+        case setSortOrder(EventListSortOrder)
+        case setYearFilter(Int?)
     }
 
     // 상태변경 이벤트 정의 (상태를 어떻게 바꿀 것인가)
@@ -28,6 +29,7 @@ final class EventListReactor: BaseReactor {
         case setFilter(EventListFilter)
         case setSortOrder(EventListSortOrder)
         case setCategories([CategoryItem])
+        case setYearFilter(Int?)
     }
 
     // View의 상태 정의 (현재 View의 상태값)
@@ -36,6 +38,7 @@ final class EventListReactor: BaseReactor {
         var filter: EventListFilter
         var sortOrder: EventListSortOrder
         var categories: [CategoryItem] = []
+        var yearFilter: Int? = nil // nil = 모든 연도
     }
 
     // 생성자에서 초기 상태 설정
@@ -62,17 +65,17 @@ final class EventListReactor: BaseReactor {
         case let .setFilter(filter):
             return .just(.setFilter(filter))
 
-        case .toggleSort:
-            return .just(
-                .setSortOrder(
-                    currentState.sortOrder == .newestFirst ? .oldestFirst : .newestFirst
-                )
-            )
+        case let .setSortOrder(order):
+            return .just(.setSortOrder(order))
 
         case .reloadCategories:
             let categoryItems = swiftDataManager.fetchAllCategories()
             return .just(.setCategories(categoryItems))
+            
+        case let .setYearFilter(year):
+            return .just(.setYearFilter(year))
         }
+        
     }
 
     // Mutation이 발생했을 때 상태(State)를 실제로 바꿈
@@ -91,6 +94,9 @@ final class EventListReactor: BaseReactor {
 
         case let .setCategories(categories):
             newState.categories = categories
+            
+        case let .setYearFilter(year):
+            newState.yearFilter = year
         }
 
         return newState

--- a/EventLogger/Scenes/EventList/EventListReactor.swift
+++ b/EventLogger/Scenes/EventList/EventListReactor.swift
@@ -21,6 +21,7 @@ final class EventListReactor: BaseReactor {
         case setFilter(EventListFilter)
         case setSortOrder(EventListSortOrder)
         case setYearFilter(Int?)
+        case goSettings
     }
 
     // 상태변경 이벤트 정의 (상태를 어떻게 바꿀 것인가)
@@ -74,6 +75,10 @@ final class EventListReactor: BaseReactor {
 
         case let .setYearFilter(year):
             return .just(.setYearFilter(year))
+            
+        case .goSettings:
+            steps.accept(AppStep.settings)
+            return .empty()
         }
     }
 

--- a/EventLogger/Scenes/EventList/EventListViewController.swift
+++ b/EventLogger/Scenes/EventList/EventListViewController.swift
@@ -63,7 +63,17 @@ final class EventListViewController: BaseViewController<EventListReactor> {
     }
     
     private lazy var addButton = UIBarButtonItem(
-        barButtonSystemItem: .add,
+        image: UIImage(systemName: "note.text.badge.plus"),
+        style: .plain,
+        target: nil,
+        action: nil
+    ).then {
+        $0.tintColor = .neutral50
+    }
+    
+    private lazy var statisticsButton = UIBarButtonItem(
+        image: UIImage(systemName: "chart.bar.xaxis"),
+        style: .plain,
         target: nil,
         action: nil
     ).then {
@@ -93,7 +103,7 @@ final class EventListViewController: BaseViewController<EventListReactor> {
         
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: titleLabel)
         
-        navigationItem.rightBarButtonItems = [sortButton, addButton]
+        navigationItem.rightBarButtonItems = [sortButton, addButton, statisticsButton]
         
         dataSource = EventListDataSource(collectionView: collectionView)
     }
@@ -137,6 +147,12 @@ final class EventListViewController: BaseViewController<EventListReactor> {
             .bind(to: reactor.steps)
             .disposed(by: disposeBag)
         
+        statisticsButton.rx.tap
+            .bind {
+                print("통계 버튼 탭함")
+            }
+            .disposed(by: disposeBag)
+        
         collectionView.rx.itemSelected
             .compactMap { [weak self] indexPath -> EventItem? in
                 self?.collectionView.deselectItem(at: indexPath, animated: true)
@@ -174,7 +190,6 @@ final class EventListViewController: BaseViewController<EventListReactor> {
         // 버튼 아이콘 업데이터 (정렬 변화 반영)
         reactor.state.map(\.sortOrder)
             .distinctUntilChanged()
-            .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] order in
                 self?.sortButton.image = UIImage(systemName: order == .newestFirst ? "arrow.up" : "arrow.down")
             })

--- a/EventLogger/Scenes/EventList/EventListViewController.swift
+++ b/EventLogger/Scenes/EventList/EventListViewController.swift
@@ -23,14 +23,23 @@ final class EventListViewController: BaseViewController<EventListReactor> {
     }
     
     private let segmentedControl = PillSegmentedControl(items: ["전체", "참여예정", "참여완료"]).then {
-        $0.font = .font17Regular
-        $0.capsuleBackgroundColor = .black
+        $0.capsuleBackgroundColor = .appBackground
         $0.capsuleBorderColor = .primary500
+        $0.capsuleShadowColor = .primary500
         $0.capsuleBorderWidth = 1
-        $0.normalTextColor = .white
-        $0.selectedTextColor = .white
         $0.borderColor = .clear
-//        $0.borderWidth = 1
+        
+        $0.normalTextColor = .neutral50
+        $0.normalFont = .font17Regular
+        
+        $0.selectedTextColor = .primary200
+        $0.selectedFont = .font17Semibold
+        
+        $0.selectedTextShadowColor = UIColor.primary500
+        $0.textShadowOpacity = 1
+        $0.textShadowRadius = 7
+        $0.textShadowOffset = CGSize(width: 0, height: 0)
+        
         $0.segmentSpacing = 6
         $0.contentInsets = .init(top: 3, leading: 3, bottom: 3, trailing: 3)
     }
@@ -50,7 +59,7 @@ final class EventListViewController: BaseViewController<EventListReactor> {
         target: nil,
         action: nil
     ).then {
-        $0.tintColor = .white
+        $0.tintColor = .neutral50
     }
     
     private lazy var addButton = UIBarButtonItem(
@@ -58,7 +67,7 @@ final class EventListViewController: BaseViewController<EventListReactor> {
         target: nil,
         action: nil
     ).then {
-        $0.tintColor = .white
+        $0.tintColor = .neutral50
     }
     
     override func setupUI() {

--- a/EventLogger/Scenes/EventList/EventListViewController.swift
+++ b/EventLogger/Scenes/EventList/EventListViewController.swift
@@ -215,12 +215,12 @@ private extension EventListViewController {
         dispatcher: ActionSubject<EventListReactor.Action>
     ) -> UIMenu {
         // 1) 정렬 액션 (단일 선택처럼 체크)
-        let newest = UIAction(title: "최신 순", image: UIImage(systemName: "arrow.up")) { [weak dispatcher] _ in
+        let newest = UIAction(title: "최신 순", image: UIImage(systemName: "arrow.down.to.line")) { [weak dispatcher] _ in
             dispatcher?.onNext(.setSortOrder(.newestFirst))
         }
         newest.state = (currentSort == .newestFirst) ? .on : .off
         
-        let oldest = UIAction(title: "오래된 순", image: UIImage(systemName: "arrow.down")) { [weak dispatcher] _ in
+        let oldest = UIAction(title: "오래된 순", image: UIImage(systemName: "arrow.up.to.line")) { [weak dispatcher] _ in
             dispatcher?.onNext(.setSortOrder(.oldestFirst))
         }
         oldest.state = (currentSort == .oldestFirst) ? .on : .off

--- a/EventLogger/Scenes/EventList/EventListViewController.swift
+++ b/EventLogger/Scenes/EventList/EventListViewController.swift
@@ -165,7 +165,7 @@ final class EventListViewController: BaseViewController<EventListReactor> {
                 reactor.state.map(\.eventItems).distinctUntilChanged(),
                 reactor.state.map(\.filter).distinctUntilChanged(),
                 reactor.state.map(\.sortOrder).distinctUntilChanged(),
-                reactor.state.map( \.yearFilter).distinctUntilChanged()
+                reactor.state.map(\.yearFilter).distinctUntilChanged()
             )
             .map { items, filter, sortOrder, yearFilter in
                 EventListSnapshotBuilder.build(input: .init(

--- a/EventLogger/Scenes/EventList/EventListViewController.swift
+++ b/EventLogger/Scenes/EventList/EventListViewController.swift
@@ -87,7 +87,8 @@ final class EventListViewController: BaseViewController<EventListReactor> {
         
         view.addSubview(backgroundGradientView)
         backgroundGradientView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.height.equalToSuperview().multipliedBy(0.5)
         }
         
         view.addSubview(segmentedControl)

--- a/EventLogger/Scenes/EventList/EventListViewController.swift
+++ b/EventLogger/Scenes/EventList/EventListViewController.swift
@@ -207,7 +207,7 @@ final class EventListViewController: BaseViewController<EventListReactor> {
 }
 
 private extension EventListViewController {
-    /// 정렬/연도 메뉴 생성
+    /// 정렬/연도/설정 메뉴 생성
     func makeSortAndYearMenu(
         items: [EventItem],
         currentSort: EventListSortOrder,
@@ -250,8 +250,14 @@ private extension EventListViewController {
         
         let yearMenu = UIMenu(title: "", options: .displayInline, children: [allYears] + yearActions)
         
-        // 3) 최종 메뉴 (위에서부터 정렬 2개, 그 다음 연도들)
-        return UIMenu(title: "", children: [sortMenu, yearMenu])
+        // 3) 설정 화면으로
+        let goSettings = UIAction(title: "설정", image: UIImage(systemName: "gearshape.fill")) { [weak dispatcher] _ in
+            dispatcher?.onNext(.goSettings)
+        }
+        
+        
+        // 4) 최종 메뉴 (위에서부터 정렬 2개, 그 다음 연도들)
+        return UIMenu(title: "", children: [sortMenu, yearMenu, goSettings])
     }
 }
 

--- a/EventLogger/Scenes/EventList/View/Cell/CategoryBadgeView.swift
+++ b/EventLogger/Scenes/EventList/View/Cell/CategoryBadgeView.swift
@@ -14,7 +14,7 @@ struct CategoryBadgeView: View {
     var body: some View {
         Text(name)
             .font(Font(UIFont.font12Medium))
-            .foregroundStyle(.white) // 지정 흰색으로 바꿔야 함
+            .foregroundStyle(Color(UIColor.neutral50))
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
             .background(color)

--- a/EventLogger/Scenes/EventList/View/Cell/EventCell.swift
+++ b/EventLogger/Scenes/EventList/View/Cell/EventCell.swift
@@ -25,7 +25,7 @@ struct EventCell: View { // EventItem 통으로 받자
                     name: category.name,
                     color: Color(uiColor: category.color)
                 )
-                .padding(.bottom, 8)
+                .padding(.bottom, 14)
                 
                 VStack {
                     Text(item.title)
@@ -57,7 +57,7 @@ struct EventCell: View { // EventItem 통으로 받자
             
             Rectangle()
                 .fill(Color.gray.opacity(0.5))
-                .frame(width: 80, height: 80)
+                .frame(width: 60, height: 60)
                 .background {
                     if let uiImage = item.image {
                         Image(uiImage: uiImage)

--- a/EventLogger/Scenes/EventList/View/Cell/EventCell.swift
+++ b/EventLogger/Scenes/EventList/View/Cell/EventCell.swift
@@ -5,8 +5,8 @@
 //  Created by 김우성 on 8/21/25.
 //
 
-import Dependencies
 import SwiftUI
+import Dependencies
 
 struct EventCategory {
     let name: String
@@ -20,6 +20,7 @@ struct EventCell: View { // EventItem 통으로 받자
     var body: some View {
         HStack(alignment: .top, spacing: 14) {
             VStack(alignment: .leading, spacing: 0) {
+                
                 CategoryBadgeView(
                     name: category.name,
                     color: Color(uiColor: category.color)
@@ -49,25 +50,26 @@ struct EventCell: View { // EventItem 통으로 받자
                         .font(Font(UIFont.font13Regular))
                         .foregroundStyle(Color(UIColor.neutral50))
                 }
-             }
+                
+            }
             
             Spacer(minLength: 0)
             
-            Rectangle()
-                .fill(Color.gray.opacity(0.5))
-                .frame(width: 60, height: 60)
-                .background {
-                    if let uiImage = item.image {
-                        Image(uiImage: uiImage)
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                    } else {
-                        Image(systemName: "photo")
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                    }
-                 }
-                .cornerRadius(10)
+            if let uiImage = item.image {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 60, height: 60)
+                    .cornerRadius(10)
+                    .clipped()
+            } else {
+                Image(systemName: "photo")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit) // placeholder는 보통 fit
+                    .frame(width: 60, height: 60)
+                    .foregroundStyle(.gray)
+                    .cornerRadius(10)
+            }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 16)

--- a/EventLogger/Scenes/EventList/View/Cell/EventCell.swift
+++ b/EventLogger/Scenes/EventList/View/Cell/EventCell.swift
@@ -74,6 +74,7 @@ struct EventCell: View { // EventItem 통으로 받자
         .padding(.horizontal, 12)
         .padding(.vertical, 16)
         .background(Color.clear)
+//        .background(Color(UIColor.primary100).opacity(0.08))
         .cornerRadius(16)
         .overlay(
             RoundedRectangle(cornerRadius: 16)

--- a/EventLogger/Scenes/EventList/View/Cell/EventCell.swift
+++ b/EventLogger/Scenes/EventList/View/Cell/EventCell.swift
@@ -30,7 +30,7 @@ struct EventCell: View { // EventItem 통으로 받자
                 VStack {
                     Text(item.title)
                         .font(Font(UIFont.font20Bold))
-                        .foregroundStyle(.white)
+                        .foregroundStyle(Color(UIColor.neutral50))
                         .lineLimit(2)
                         .truncationMode(.tail)
                         .multilineTextAlignment(.leading)
@@ -42,13 +42,13 @@ struct EventCell: View { // EventItem 통으로 받자
                 
                 Text("\(DateFormatter.toDateString(item.startTime)) ∙ 시작 \(DateFormatter.toTimeString(item.startTime))")
                     .font(Font(UIFont.font13Regular))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(Color(UIColor.neutral50))
                     .padding(.bottom, 4)
                 
                 if let location = item.location, !location.isEmpty {
                     Text(location)
                         .font(Font(UIFont.font13Regular))
-                        .foregroundStyle(.white)
+                        .foregroundStyle(Color(UIColor.neutral50))
                 }
                 
             }
@@ -78,7 +78,7 @@ struct EventCell: View { // EventItem 통으로 받자
         .cornerRadius(16)
         .overlay(
             RoundedRectangle(cornerRadius: 16)
-                .stroke(Color.white.opacity(0.40), lineWidth: 1)
+                .stroke(Color(UIColor.neutral50).opacity(0.40), lineWidth: 1)
         )
     }
 }

--- a/EventLogger/Scenes/EventList/View/Cell/EventCell.swift
+++ b/EventLogger/Scenes/EventList/View/Cell/EventCell.swift
@@ -5,8 +5,8 @@
 //  Created by 김우성 on 8/21/25.
 //
 
-import SwiftUI
 import Dependencies
+import SwiftUI
 
 struct EventCategory {
     let name: String
@@ -20,7 +20,6 @@ struct EventCell: View { // EventItem 통으로 받자
     var body: some View {
         HStack(alignment: .top, spacing: 14) {
             VStack(alignment: .leading, spacing: 0) {
-                
                 CategoryBadgeView(
                     name: category.name,
                     color: Color(uiColor: category.color)
@@ -50,8 +49,7 @@ struct EventCell: View { // EventItem 통으로 받자
                         .font(Font(UIFont.font13Regular))
                         .foregroundStyle(Color(UIColor.neutral50))
                 }
-                
-            }
+             }
             
             Spacer(minLength: 0)
             
@@ -68,8 +66,7 @@ struct EventCell: View { // EventItem 통으로 받자
                             .resizable()
                             .aspectRatio(contentMode: .fill)
                     }
-                        
-                }
+                 }
                 .cornerRadius(10)
         }
         .padding(.horizontal, 12)

--- a/EventLogger/Scenes/EventList/View/GradientBackgroundView.swift
+++ b/EventLogger/Scenes/EventList/View/GradientBackgroundView.swift
@@ -24,7 +24,8 @@ final class GradientBackgroundView: UIView {
     
     /// 그라데이션 방향 (기본: 위→아래)
     var direction: (start: CGPoint, end: CGPoint) = (CGPoint(x: 0.5, y: 0.0),
-                                                     CGPoint(x: 0.5, y: 1.0)) {
+                                                     CGPoint(x: 0.5, y: 1.0))
+    {
         didSet {
             gradient.startPoint = direction.start
             gradient.endPoint = direction.end
@@ -36,15 +37,16 @@ final class GradientBackgroundView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         // 만약 layerClass를 쓰면 gradient = self.layer as! CAGradientLayer 로 바로 접근 가능
-        if let g = self.layer as? CAGradientLayer {
+        if let g = layer as? CAGradientLayer {
             gradient.colors = nil // dummy, 곧 updateGradient에서 세팅
         } else {
             layer.addSublayer(gradient)
         }
-        isUserInteractionEnabled = false  // 배경이므로 이벤트 막지 않게
+        isUserInteractionEnabled = false // 배경이므로 이벤트 막지 않게
         updateGradient()
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
     
     override func layoutSubviews() {
@@ -57,7 +59,7 @@ final class GradientBackgroundView: UIView {
     
     private func updateGradient() {
         let cgColors = colors.map { $0.cgColor }
-        if let gradientLayer = self.layer as? CAGradientLayer {
+        if let gradientLayer = layer as? CAGradientLayer {
             gradientLayer.colors = cgColors
             gradientLayer.locations = locations
             gradientLayer.startPoint = direction.start

--- a/EventLogger/Scenes/EventList/View/Layout/EventListDataSource.swift
+++ b/EventLogger/Scenes/EventList/View/Layout/EventListDataSource.swift
@@ -5,10 +5,10 @@
 //  Created by 김우성 on 8/25/25.
 //
 
+import Dependencies
 import SnapKit
 import SwiftUI
 import UIKit
-import Dependencies
 
 /// Diffable DataSource & 헤더 등록 담당
 final class EventListDataSource {
@@ -36,7 +36,7 @@ final class EventListDataSource {
         guard let idItem = dataSource.itemIdentifier(for: indexPath) else { return nil }
         let eventID: UUID
         switch idItem {
-        case let .nextUp(id), let .monthEvent(id): eventID = id
+        case .nextUp(let id), .monthEvent(let id): eventID = id
         }
         return itemsByID[eventID]
     }
@@ -45,7 +45,6 @@ final class EventListDataSource {
         // Cell: SwiftUI EventCell를 iOS 17의 UIHostingConfiguration으로 올림
         let cellRegistration = UICollectionView.CellRegistration<UICollectionViewCell, EventListDSItem> { [weak self] cell, _, item in
             @Dependency(\.swiftDataManager) var swiftDataManager
-            
             
             guard let self else { return }
             let event: EventItem? = {

--- a/EventLogger/Scenes/EventList/View/Layout/EventListDataSource.swift
+++ b/EventLogger/Scenes/EventList/View/Layout/EventListDataSource.swift
@@ -77,7 +77,7 @@ final class EventListDataSource {
             } else {
                 label = UILabel()
                 label.tag = tag
-                label.textColor = .white
+                label.textColor = .neutral50
                 label.font = .font17Bold
                 header.addSubview(label)
                 label.snp.makeConstraints {

--- a/EventLogger/Scenes/Schedule/View/ArtistsFieldContainerView.swift
+++ b/EventLogger/Scenes/Schedule/View/ArtistsFieldContainerView.swift
@@ -27,13 +27,13 @@ final class ArtistsFieldContainerView: UIView {
 
         $0.placeholder = "출연자를 입력하세요"
         $0.placeholderFont = .font16Regular
-        $0.placeholderColor = .white
+        $0.placeholderColor = .neutral50
         $0.cornerRadius = 10
 
 //        $0.tintColor = .systemOrange
-        $0.textColor = .white
+        $0.textColor = .neutral50
         $0.selectedColor = UIColor(red: 145.0 / 255.0, green: 60.0 / 255.0, blue: 3.0 / 255.0, alpha: 1.0)
-        $0.selectedTextColor = .white
+        $0.selectedTextColor = .neutral50
         $0.font = .font16Regular
         $0.acceptTagOption = .return
 

--- a/EventLogger/Scenes/Schedule/View/CategoryField/CategoryFieldContainerView.swift
+++ b/EventLogger/Scenes/Schedule/View/CategoryField/CategoryFieldContainerView.swift
@@ -20,7 +20,7 @@ final class CategoryFieldContainerView: UIView {
     let sectionHeader = UILabel().then {
         $0.text = "카테고리"
         $0.font = .font13Regular
-        $0.textColor = .white
+        $0.textColor = .neutral50
     }
 
     let categoryMenuButton = CategoryDropDownButton().then {

--- a/EventLogger/Scenes/Schedule/View/DateRangeFieldContainerView.swift
+++ b/EventLogger/Scenes/Schedule/View/DateRangeFieldContainerView.swift
@@ -27,7 +27,7 @@ final class DateRangeFieldContainerView: UIView {
     private let sectionHeader = UILabel().then {
         $0.text = "날짜 및 시간"
         $0.font = .font13Regular
-        $0.textColor = .white // Neutral/50으로 수정예정
+        $0.textColor = .neutral50
     }
     
     private let cardView = UIView().then {
@@ -55,7 +55,7 @@ final class DateRangeFieldContainerView: UIView {
     private let startLabel = UILabel().then {
         $0.text = "시작 시간"
         $0.font = .font17Regular
-        $0.textColor = .white
+        $0.textColor = .neutral50
         $0.setContentHuggingPriority(.required, for: .horizontal)
     }
     
@@ -98,7 +98,7 @@ final class DateRangeFieldContainerView: UIView {
     private let endLabel = UILabel().then {
         $0.text = "종료 시간"
         $0.font = .font17Regular
-        $0.textColor = .white
+        $0.textColor = .neutral50
         $0.setContentHuggingPriority(.required, for: .horizontal)
     }
 


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #40 

<br>

### 🦁 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->
- white로 작성됐던 코드부분 모두 neutral50으로 변경
- 세그먼트 컨트롤 선택된 곳 글로우 디자인 반영
- 이벤트셀 디자인에 맞춰 변경, 패딩값 변경, 통계버튼 추가, UIMenu 기반 작업
  - EventItem에 이미지 저장된 경우 이벤트셀에 이미지 보여줌
  - 정렬 버튼 대신 메뉴 버튼 생성 
  - toggleSort 액션 제거, setSortOrder와 setYearFilter 액션 추가
  - 상태 필터와 연도 필터를 함께 적용할 수 있도록 설정
  - 정렬과 연도 메뉴를 생성해 리턴하는 makeSortAndYearMenu 함수 작성

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->

https://github.com/user-attachments/assets/2920fff2-d771-4809-8001-f19d2d8f3ba3
- 최신순, 오래된순 심볼 바꿨어요
<img width="228" height="243" alt="스크린샷 2025-09-01 19 14 33" src="https://github.com/user-attachments/assets/8d27240b-3249-4c23-8053-fed4c24f1dc5" />


- 설정으로 가는 UIMenu 항목 추가했어요

https://github.com/user-attachments/assets/bc1928ea-4b13-4258-b53c-ec9f17235a34

- 뒷배경 그라데이션 덜올라오게 바꿨습니다

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-01 at 20 49 40" src="https://github.com/user-attachments/assets/9dba533a-03b0-42e2-ab1c-468e51bcbb8e" />

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->
- 드디어 통계 들어갑니다

<br>
