### PR TITLE
[Fix] #54 이벤트 상세 뷰의 InfoItemView 새로 스택으로 구성

### DIFF
--- a/EventLogger/Scenes/EventDetail/View/InfoItemView.swift
+++ b/EventLogger/Scenes/EventDetail/View/InfoItemView.swift
@@ -5,10 +5,10 @@
 //  Created by 김우성 on 9/5/25.
 //
 
+import Dependencies
 import SnapKit
 import Then
 import UIKit
-import Dependencies
 
 // 정보 카드 부분 뷰
 class InfoItemView: UIView {
@@ -50,6 +50,7 @@ class InfoItemView: UIView {
         setupUI()
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -74,9 +75,7 @@ class InfoItemView: UIView {
         }
         buttonStackView.addArrangedSubview(addCalendarButton)
         buttonStackView.addArrangedSubview(findDirectionsButton)
-        
-    }
-    
+     }
     
     private func makeInfoHStack(icon: String, value: String) -> UIStackView {
         let iconImageView = UIImageView(image: UIImage(systemName: icon, withConfiguration: .font17Regular)).then {
@@ -108,7 +107,7 @@ class InfoItemView: UIView {
         let categories = swiftDataManager.fetchAllCategories()
         
         let date = DateFormatter.toDateString(eventItem.startTime)
-        let categoryName = categories.first{ $0.id == eventItem.categoryId }?.name ?? ""
+        let categoryName = categories.first { $0.id == eventItem.categoryId }?.name ?? ""
         let time = "시작 \(DateFormatter.toTimeString(eventItem.startTime)) / 종료 \(DateFormatter.toTimeString(eventItem.endTime)) 예정"
         let location = eventItem.location ?? ""
         let artists = eventItem.artists.joined(separator: ", ")

--- a/EventLogger/Scenes/EventDetail/View/InfoItemView.swift
+++ b/EventLogger/Scenes/EventDetail/View/InfoItemView.swift
@@ -2,7 +2,7 @@
 //  InfoItemView.swift
 //  EventLogger
 //
-//  Created by Yoon on 8/22/25.
+//  Created by 김우성 on 9/5/25.
 //
 
 import SnapKit
@@ -12,85 +12,18 @@ import Dependencies
 
 // 정보 카드 부분 뷰
 class InfoItemView: UIView {
-    // 정보 영역 컨테이너 뷰
     private let infoCardView = UIView().then {
         $0.backgroundColor = .systemGray6
         $0.layer.cornerRadius = 12
     }
-
-    // MARK: Label
-
-    private let dateLabel = UILabel().then {
-        $0.font = .font17Regular
+    
+    private let infoVStack = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 16
+        $0.alignment = .leading
+        $0.distribution = .fill
     }
-
-    private let categoryLabel = UILabel().then {
-        $0.font = .font17Regular
-    }
-
-    private let timelabel = UILabel().then {
-        $0.font = .font17Regular
-    }
-
-    private let locationLabel = UILabel().then {
-        $0.font = .font17Regular
-    }
-
-    private let artistsLabel = UILabel().then {
-        $0.font = .font17Regular
-        $0.numberOfLines = 0
-    }
-
-    private let expenseLabel = UILabel().then {
-        $0.font = .font17Regular
-    }
-
-    // MARK: SF Symbol
-
-    private let calendarIcon = UIImageView(image: UIImage(
-        systemName: "calendar",
-        withConfiguration: .font17Regular
-    )).then {
-        $0.tintColor = .primary500
-    }
-
-    private let tagIcon = UIImageView(image: UIImage(
-        systemName: "tag",
-        withConfiguration: .font17Regular
-    )).then {
-        $0.tintColor = .primary500
-    }
-
-    private let clockIcon = UIImageView(image: UIImage(
-        systemName: "clock",
-        withConfiguration: .font17Regular
-    )).then {
-        $0.tintColor = .primary500
-    }
-
-    private let mapPinIcon = UIImageView(image: UIImage(
-        systemName: "mappin.and.ellipse",
-        withConfiguration: .font17Regular
-    )).then {
-        $0.tintColor = .primary500
-    }
-
-    private let personIcon = UIImageView(image: UIImage(
-        systemName: "person",
-        withConfiguration: .font17Regular
-    )).then {
-        $0.tintColor = .primary500
-    }
-
-    private let moneysignIcon = UIImageView(image: UIImage(
-        systemName: "wonsign.circle",
-        withConfiguration: .font17Regular
-    )).then {
-        $0.tintColor = .primary500
-    }
-
-    // MARK: Button
-
+    
     let addCalendarButton = UIButton(configuration: .defaultButton).then {
         $0.configuration?.title = "캘린더에 추가"
         $0.configuration?.baseBackgroundColor = .primary500
@@ -103,142 +36,89 @@ class InfoItemView: UIView {
         $0.configuration?.background.strokeColor = .primary500
         $0.configuration?.background.strokeWidth = 1
     }
-
-    // MARK: StackView
-
+    
     private let buttonStackView = UIStackView().then {
         $0.axis = .horizontal
         $0.spacing = 16
         $0.alignment = .fill
         $0.distribution = .fillEqually
     }
-
-    // MARK: init
-
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
-
-        // 뷰 주입
+        
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupUI() {
         addSubview(infoCardView)
-        infoCardView.addSubview(dateLabel)
-        infoCardView.addSubview(categoryLabel)
-        infoCardView.addSubview(timelabel)
-        infoCardView.addSubview(locationLabel)
-        infoCardView.addSubview(artistsLabel)
-        infoCardView.addSubview(expenseLabel)
-        infoCardView.addSubview(calendarIcon)
-        infoCardView.addSubview(tagIcon)
-        infoCardView.addSubview(clockIcon)
-        infoCardView.addSubview(mapPinIcon)
-        infoCardView.addSubview(personIcon)
-        infoCardView.addSubview(moneysignIcon)
-
+        infoCardView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        infoCardView.addSubview(infoVStack)
+        infoVStack.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview().inset(16)
+        }
+        
+        infoCardView.addSubview(buttonStackView)
+        buttonStackView.snp.makeConstraints {
+            $0.top.equalTo(infoVStack.snp.bottom).offset(24)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.height.equalTo(42)
+            $0.bottom.equalToSuperview().inset(16)
+        }
         buttonStackView.addArrangedSubview(addCalendarButton)
         buttonStackView.addArrangedSubview(findDirectionsButton)
-
-        infoCardView.addSubview(buttonStackView)
-
-        // 오토 레이아웃
-        infoCardView.snp.makeConstraints {
-            $0.directionalEdges.equalToSuperview()
-        }
-
-        calendarIcon.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(20)
-            $0.leading.equalToSuperview().offset(20)
-        }
-
-        dateLabel.snp.makeConstraints {
-            $0.top.equalTo(calendarIcon)
-            $0.leading.equalTo(calendarIcon.snp.trailing).offset(10)
-        }
-
-        tagIcon.snp.makeConstraints {
-            $0.top.equalTo(calendarIcon.snp.bottom).offset(16)
-            $0.leading.equalToSuperview().offset(20)
-        }
-
-        categoryLabel.snp.makeConstraints {
-            $0.top.equalTo(tagIcon)
-            $0.leading.equalTo(tagIcon.snp.trailing).offset(8)
-        }
-
-        clockIcon.snp.makeConstraints {
-            $0.top.equalTo(tagIcon.snp.bottom).offset(16)
-            $0.leading.equalToSuperview().offset(20)
-        }
-
-        timelabel.snp.makeConstraints {
-            $0.top.equalTo(clockIcon)
-            $0.leading.equalTo(clockIcon.snp.trailing).offset(11)
-        }
-
-        mapPinIcon.snp.makeConstraints {
-            $0.top.equalTo(clockIcon.snp.bottom).offset(16)
-            $0.leading.equalToSuperview().offset(20)
-        }
-
-        locationLabel.snp.makeConstraints {
-            $0.top.equalTo(mapPinIcon)
-            $0.leading.equalTo(mapPinIcon.snp.trailing).offset(12)
-        }
-
-        personIcon.snp.makeConstraints {
-            $0.top.equalTo(mapPinIcon.snp.bottom).offset(16)
-            $0.leading.equalToSuperview().offset(20)
-        }
-
-        artistsLabel.snp.makeConstraints {
-            $0.top.equalTo(personIcon)
-            $0.leading.equalTo(personIcon.snp.trailing).offset(12)
-            $0.trailing.equalToSuperview().inset(10)
-        }
-
-        moneysignIcon.snp.makeConstraints {
-            $0.top.equalTo(artistsLabel.snp.bottom).offset(16)
-            $0.leading.equalToSuperview().offset(20)
-        }
-
-        expenseLabel.snp.makeConstraints {
-            $0.top.equalTo(moneysignIcon)
-            $0.leading.equalTo(moneysignIcon.snp.trailing).offset(11)
-        }
-
-        buttonStackView.snp.makeConstraints {
-            $0.top.equalTo(moneysignIcon.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(16)
-            $0.height.equalTo(39)
-            $0.bottom.equalToSuperview().offset(-20)
-        }
+        
     }
-
-    // 리액터에 바인딩 되는 값 주입
+    
+    
+    private func makeInfoHStack(icon: String, value: String) -> UIStackView {
+        let iconImageView = UIImageView(image: UIImage(systemName: icon, withConfiguration: .font17Regular)).then {
+            $0.tintColor = .primary500
+            
+            // SF Symbol의 가로폭이 달라지는 문제를 해결하기 위해 명시적으로 크기 고정
+            $0.snp.makeConstraints { make in
+                make.width.equalTo(20)
+                make.height.equalTo(20)
+            }
+        }
+        
+        let titleLabel = UILabel().then {
+            $0.text = value
+            $0.font = .font17Regular
+            $0.numberOfLines = 0
+        }
+        
+        let hStack = UIStackView(arrangedSubviews: [iconImageView, titleLabel]).then {
+            $0.axis = .horizontal
+            $0.spacing = 10
+            $0.alignment = .top
+        }
+        return hStack
+    }
+    
     func configureView(eventItem: EventItem) {
         @Dependency(\.swiftDataManager) var swiftDataManager
         let categories = swiftDataManager.fetchAllCategories()
-        let categoryName = categories.first{ $0.id == eventItem.categoryId }?.name
         
-        dateLabel.text = DateFormatter.toDateString(eventItem.startTime)
-        categoryLabel.text = categoryName
-        timelabel.text = makeTimeLabel(startTime: eventItem.startTime, endTime: eventItem.endTime)
-        locationLabel.text = eventItem.location
-        artistsLabel.text = makeArtistsLabel(eventItem.artists)
-        expenseLabel.text = "\(eventItem.expense.formatted(.number))원"
+        let date = DateFormatter.toDateString(eventItem.startTime)
+        let categoryName = categories.first{ $0.id == eventItem.categoryId }?.name ?? ""
+        let time = "시작 \(DateFormatter.toTimeString(eventItem.startTime)) / 종료 \(DateFormatter.toTimeString(eventItem.endTime)) 예정"
+        let location = eventItem.location ?? ""
+        let artists = eventItem.artists.joined(separator: ", ")
+        let expense = "\(eventItem.expense.formatted(.number))원"
         
-    }
-
-    // 시간 라벨 String 리턴
-    private func makeTimeLabel(startTime: Date, endTime: Date) -> String {
-        "시작 \(DateFormatter.toTimeString(startTime)) / 종료 \(DateFormatter.toTimeString(endTime)) 예정"
-    }
-
-    // Artists 배열 String화
-    private func makeArtistsLabel(_ artists: [String]) -> String {
-        return artists.joined(separator: ", ")
-    }
-
-    @available(*, unavailable)
-    required init?(coder _: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        infoVStack.addArrangedSubview(makeInfoHStack(icon: "calendar", value: date))
+        infoVStack.addArrangedSubview(makeInfoHStack(icon: "tag", value: categoryName))
+        infoVStack.addArrangedSubview(makeInfoHStack(icon: "clock", value: time))
+        infoVStack.addArrangedSubview(makeInfoHStack(icon: "mappin.and.ellipse", value: location))
+        infoVStack.addArrangedSubview(makeInfoHStack(icon: "person", value: artists))
+        infoVStack.addArrangedSubview(makeInfoHStack(icon: "wonsign.circle", value: expense))
     }
 }


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #54 

<br>

### 🦁 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

HStack과 VStack의 조합으로 재구성했습니다.


<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  
-->
  <img width="300" alt="" src="https://github.com/user-attachments/assets/95a46659-333e-419b-9635-5309f43f28cb">

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->
SF 심볼의 사이즈를 snp.makeConstraints 로 20x20으로 명시적으로 주니까 들쭉날쭉하지 않네요 

<br>
