### PR TITLE
[Fix] #54 런치스크린 수정, 일정 등록 화면에서 카테고리 없을 때 등록버튼 비활성화

### DIFF
--- a/EventLogger/Resources/Base.lproj/LaunchScreen.storyboard
+++ b/EventLogger/Resources/Base.lproj/LaunchScreen.storyboard
@@ -16,17 +16,29 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="LaunchBottom" translatesAutoresizingMaskIntoConstraints="NO" id="XKm-LI-8vU">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="LaunchBottom" translatesAutoresizingMaskIntoConstraints="NO" id="XKm-LI-8vU">
                                 <rect key="frame" x="0.0" y="724" width="393" height="128"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="XKm-LI-8vU" secondAttribute="height" multiplier="393:128" id="gmI-ga-JJo"/>
+                                </constraints>
                             </imageView>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="LaunchLogo" translatesAutoresizingMaskIntoConstraints="NO" id="pqy-JF-4eQ">
-                                <rect key="frame" x="117" y="373" width="174" height="92"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="LaunchLogo" translatesAutoresizingMaskIntoConstraints="NO" id="pqy-JF-4eQ">
+                                <rect key="frame" x="98.333333333333314" y="379.33333333333331" width="196.33333333333337" height="93.333333333333314"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="pqy-JF-4eQ" secondAttribute="height" multiplier="625:297" id="XyP-l6-0d0"/>
+                                </constraints>
                             </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="pqy-JF-4eQ" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="4nm-U3-fkn"/>
+                            <constraint firstItem="pqy-JF-4eQ" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="7CY-2G-uRZ"/>
+                            <constraint firstItem="XKm-LI-8vU" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="Pjt-1z-jFh"/>
+                            <constraint firstItem="pqy-JF-4eQ" firstAttribute="width" secondItem="Ze5-6b-2t3" secondAttribute="width" multiplier="1/2" id="bYV-bc-33x"/>
+                            <constraint firstItem="XKm-LI-8vU" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="l5g-M4-4qz"/>
+                            <constraint firstAttribute="bottom" secondItem="XKm-LI-8vU" secondAttribute="bottom" id="wyJ-Sm-XLj"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/EventLogger/Scenes/Schedule/ScheduleViewController.swift
+++ b/EventLogger/Scenes/Schedule/ScheduleViewController.swift
@@ -175,11 +175,15 @@ class ScheduleViewController: BaseViewController<ScheduleReactor> {
         let isTitleValid = inputTitleView.textField.rx.text
             .orEmpty
             .map { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-            .distinctUntilChanged()
-            .share(replay: 1)
         
-        // 버튼 활성 바인딩 (UIButton은 isEnabled=false면 탭 이벤트도 막힘)
-        isTitleValid
+        // 카테고리 존재 여부
+        let hasCategory = reactor.state
+            .map(\.categories)
+            .map { !$0.isEmpty }
+        
+        // 버튼 활성 바인딩 (제목 적었고, 카테고리 0개 아닐 때) (UIButton은 isEnabled=false면 탭 이벤트도 막힘)
+        Observable
+            .combineLatest(isTitleValid, hasCategory) { $0 && $1 }
             .bind(to: bottomButton.rx.isEnabled)
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #54 

<br>

### 🦁 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

- 런치스크린 수정
- 일정 등록 화면에서 카테고리 없을 때 등록버튼 비활성화

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇

-->
  <img width="300" alt="" src="https://github.com/user-attachments/assets/0d29c446-5d2a-4299-a849-699d58e1a6b8">  

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->
- 이어서 이벤트리스트 전체적 수정 중입니다 버그잡기

<br>
