### PR TITLE
[Feat] #60 이벤트리스트 목록에 보여줄 거 없을 때 띄워줄 뷰 구현

### DIFF
--- a/EventLogger/Scenes/EventList/EventListDataSource.swift
+++ b/EventLogger/Scenes/EventList/EventListDataSource.swift
@@ -30,6 +30,9 @@ final class EventListDataSource {
     
     func apply(_ snapshot: NSDiffableDataSourceSnapshot<EventListSection, EventListDSItem>, animated: Bool) {
         dataSource.apply(snapshot, animatingDifferences: animated)
+        
+        let isEmpty = snapshot.itemIdentifiers.isEmpty
+        collectionView?.backgroundView?.isHidden = !isEmpty
     }
     
     func eventItem(at indexPath: IndexPath) -> EventItem? {

--- a/EventLogger/Scenes/EventList/EventListViewController.swift
+++ b/EventLogger/Scenes/EventList/EventListViewController.swift
@@ -48,6 +48,34 @@ final class EventListViewController: BaseViewController<EventListReactor> {
         $0.showsVerticalScrollIndicator = true
     }
     
+    private let emptyView = UIView().then {
+        $0.backgroundColor = .clear
+    }
+
+    private let emptyStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.alignment = .center
+        $0.distribution = .fill
+        $0.spacing = 10
+        $0.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    private let emptyTitleLabel = UILabel().then {
+        $0.text = "보여드릴 이벤트가 없어요"
+        $0.textColor = .neutral50
+        $0.font = .font20Bold
+        $0.textAlignment = .center
+        $0.numberOfLines = 0
+    }
+
+    private let emptyValueLabel = UILabel().then {
+        $0.text = "일정을 등록하고 한눈에 관리해 보세요"
+        $0.textColor = .neutral50
+        $0.font = .font17Regular
+        $0.textAlignment = .center
+        $0.numberOfLines = 0
+    }
+    
     private lazy var dataSource = EventListDataSource(collectionView: collectionView)
     private var currentItemsByID: [UUID: EventItem] = [:]
     
@@ -93,6 +121,14 @@ final class EventListViewController: BaseViewController<EventListReactor> {
             $0.top.equalTo(segmentedControl.snp.bottom).offset(10)
             $0.leading.trailing.bottom.equalToSuperview()
         }
+        collectionView.backgroundView = emptyView
+        emptyView.addSubview(emptyStackView)
+        emptyStackView.addArrangedSubview(emptyTitleLabel)
+        emptyStackView.addArrangedSubview(emptyValueLabel)
+        emptyStackView.snp.makeConstraints {
+            $0.center.equalTo(view.safeAreaLayoutGuide)
+        }
+        emptyView.isHidden = true
         
         view.addSubview(addButton)
         addButton.snp.makeConstraints {

--- a/EventLogger/Scenes/Statistics/Stats+Snapshot.swift
+++ b/EventLogger/Scenes/Statistics/Stats+Snapshot.swift
@@ -8,13 +8,12 @@
 import UIKit
 
 extension StatsViewController {
-
     func applySnapshot(animated: Bool) {
         guard let reactor = reactor, let dataSource = dataSource else { return }
-        
+
         // 스냅샷을 다시 그릴 때마다 캐시 초기화
         resetRollupCaches()
-        
+
         let state = reactor.currentState
 
         var snapshot = NSDiffableDataSourceSnapshot<StatsSection, StatsItem>()
@@ -53,11 +52,11 @@ extension StatsViewController {
         if snapshot.sectionIdentifiers.contains(.heatmapHeader) {
             snapshot.appendItems([.heatmapHeaderTitle("활동 리포트")], toSection: .heatmapHeader)
         }
-        
+
         if snapshot.sectionIdentifiers.contains(.heatmap) {
             snapshot.appendItems([.heatmap(reactor.currentState.heatmap)], toSection: .heatmap)
         }
-        
+
         if snapshot.sectionIdentifiers.contains(.heatmapFooter) {
             snapshot.appendItems([.heatmapLegend(UUID())], toSection: .heatmapFooter)
         }
@@ -82,9 +81,22 @@ extension StatsViewController {
 
         // 5) 총합
         let (cnt, expense) = statisticsService.total(for: period)
+        
+//        if cnt == 0 {
+//            collectionView.backgroundView?.isHidden = false
+//            collectionView.showsVerticalScrollIndicator = false
+//            
+//            // 비어있는 스냅샷 적용 (아이템/섹션 0개여야 backgroundView가 보입니다)
+//            let empty = NSDiffableDataSourceSnapshot<StatsSection, StatsItem>()
+//            dataSource.apply(empty, animatingDifferences: animated)
+//            return
+//        } else {
+//            collectionView.backgroundView?.isHidden = true
+//            collectionView.showsVerticalScrollIndicator = true
+//        }
+        
         snapshot.appendItems([.totalCount(.init(totalCount: cnt, totalExpense: expense))], toSection: .totalCount)
         snapshot.appendItems([.totalExpense(.init(totalCount: cnt, totalExpense: expense))], toSection: .totalExpense)
-
 
         // 6) 카테고리 Count/Expense (하위 포함)
         let categoryStats = statisticsService.categoryStats(for: period) // count desc
@@ -244,4 +256,3 @@ extension StatsViewController {
         snapshot.appendItems(items, toSection: section)
     }
 }
-

--- a/EventLogger/Scenes/Statistics/StatsViewController.swift
+++ b/EventLogger/Scenes/Statistics/StatsViewController.swift
@@ -50,6 +50,34 @@ final class StatsViewController: BaseViewController<StatsReactor> {
         $0.layoutMargins = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
     }
     
+    private let emptyView = UIView().then {
+        $0.backgroundColor = .clear
+    }
+
+    private let emptyStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.alignment = .center
+        $0.distribution = .fill
+        $0.spacing = 10
+        $0.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    private let emptyTitleLabel = UILabel().then {
+        $0.text = "보여드릴 통계가 없어요"
+        $0.textColor = .neutral50
+        $0.font = .font20Bold
+        $0.textAlignment = .center
+        $0.numberOfLines = 0
+    }
+
+    private let emptyValueLabel = UILabel().then {
+        $0.text = "일정을 등록하면 통계를 보여드릴 수 있어요"
+        $0.textColor = .neutral50
+        $0.font = .font17Regular
+        $0.textAlignment = .center
+        $0.numberOfLines = 0
+    }
+    
     let notification = NSPersistentCloudKitContainer.eventChangedNotification
 
     // MARK: Diffable
@@ -117,13 +145,27 @@ final class StatsViewController: BaseViewController<StatsReactor> {
         }
 
         view.addSubview(collectionView)
+        collectionView.backgroundView = emptyView
+        emptyView.isHidden = true
         collectionView.snp.makeConstraints {
             $0.top.equalTo(segmentedControl.snp.bottom).offset(12)
             $0.leading.trailing.bottom.equalToSuperview()
         }
+        
+        setupEmptyView()
 
         configureDataSource()
         collectionView.delegate = self // 셀 탭 감지를 위해 델리게이트 설정
+    }
+    
+    private func setupEmptyView() {
+        emptyView.addSubview(emptyStackView)
+        emptyStackView.addArrangedSubview(emptyTitleLabel)
+        emptyStackView.addArrangedSubview(emptyValueLabel)
+        
+        emptyStackView.snp.makeConstraints {
+            $0.center.equalTo(view.safeAreaLayoutGuide)
+        }
     }
 
     override func bind(reactor: StatsReactor) {


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #60 

<br>

### 🦁 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

- 이벤트리스트 목록에 보여줄 거 없을 때 띄워줄 뷰 구현 했습니다

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->
 <img width="300" alt="" src="https://github.com/user-attachments/assets/0a763ba9-9124-4fc3-a386-3477d849f02a">

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->


<br>
