### PR TITLE
Feat/#57 일정 수정/삭제시 연동해서 캘린더에 수정

### DIFF
--- a/EventLogger/App/Dependencies.swift
+++ b/EventLogger/App/Dependencies.swift
@@ -11,11 +11,6 @@ import SwiftData
 
 // 실제 사용할 의존성 주입된 변수
 extension DependencyValues {
-    var modelContext: ModelContext {
-        get { self[ModelContextKey.self] }
-        set { self[ModelContextKey.self] = newValue }
-    }
-
     var swiftDataManager: SwiftDataManager {
         get { self[SwiftDataManagerKey.self] }
         set { self[SwiftDataManagerKey.self] = newValue }
@@ -37,20 +32,6 @@ extension DependencyValues {
     }
 }
 
-// MARK: ModelContext
-
-private enum ModelContextKey: DependencyKey {
-    static var liveValue: ModelContext {
-        ModelContext(Persistence.container)
-    }
-
-    static var testValue: ModelContext {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let schema = Schema([CategoryStore.self, EventStore.self])
-        let container = try! ModelContainer(for: schema, configurations: config)
-        return ModelContext(container)
-    }
-}
 
 // MARK: SwiftData Manager
 
@@ -78,8 +59,6 @@ private enum NotificationServiceKey: DependencyKey {
     static var liveValue: NotificationServicing = NotificationService()
     static var testValue: NotificationServicing = NotificationService() // 테스트용
 }
-
-extension ModelContext: @unchecked @retroactive Sendable {}
 
 
 

--- a/EventLogger/App/UserSetting.swift
+++ b/EventLogger/App/UserSetting.swift
@@ -36,11 +36,13 @@ enum UDKey {
     static let didSetupDefaultCategories = "didSetupDefaultCategories" // 최초 실행 체크
     static let pushNotificationEnabled = "pushNotificationEnabled" // 푸쉬알림 허용 체크
     static let autoSaveToCalendar = "settings.autoSaveToCalendar" // 캘린더 오토세이브
+    static let appCalendarName = "appCalendarName"
+    static let appCalendarIdKey = "ELCalendarIdentifier"
 }
 
 /*
  didSetupDefaultCategories를 쓴다면
- @UserSEtting(key: UDKey.didSetupDefaultCategories, defaultValue: false)
+ @UserSetting(key: UDKey.didSetupDefaultCategories, defaultValue: false)
 var didSetupDefaultCategories: Type
  위처럼 변수 선언하고 변수 쓰듯이 쓰면 됨 유저디폴트 값이 없으면 defaultValue로 선언한게 들어감
  */

--- a/EventLogger/Scenes/EventDetail/EventDetailReactor.swift
+++ b/EventLogger/Scenes/EventDetail/EventDetailReactor.swift
@@ -26,7 +26,7 @@ final class EventDetailReactor: BaseReactor {
     // 사용자 액션 정의 (사용자의 의도)
     enum Action {
         case moveToEdit(EventItem)
-        case deleteEvent(UUID, String?)
+        case deleteEvent(EventItem)
         case addToCalendarTapped
     }
     
@@ -60,20 +60,18 @@ final class EventDetailReactor: BaseReactor {
         case let .moveToEdit(item):
             steps.accept(AppStep.updateSchedule(item))
             return .empty()
-        case let .deleteEvent(eventId, calendarId):
+        case let .deleteEvent(eventItem):
             @Dependency(\.swiftDataManager) var swiftDataManager
-            swiftDataManager.deleteEvent(id: eventId)
+            swiftDataManager.deleteEvent(id: eventItem.id)
             
             // 캘린더에도 삭제 반영
-            if let calendarId {
-                calendarService.delete(eventId: calendarId)
-                    .subscribe()
-                    .disposed(by: disposeBag)
-            }
+            calendarService.delete(eventItem: eventItem)
+                 .subscribe()
+                 .disposed(by: disposeBag)
             
             // 알림도 취소
             @Dependency(\.notificationService) var notificationService
-            notificationService.cancelNotification(id: eventId.uuidString)
+            notificationService.cancelNotification(id: eventItem.id.uuidString)
             
             steps.accept(AppStep.eventList)
             return .empty()

--- a/EventLogger/Scenes/EventDetail/EventDetailReactor.swift
+++ b/EventLogger/Scenes/EventDetail/EventDetailReactor.swift
@@ -26,18 +26,18 @@ final class EventDetailReactor: BaseReactor {
     // 사용자 액션 정의 (사용자의 의도)
     enum Action {
         case moveToEdit(EventItem)
-        case deleteEvent(UUID)
+        case deleteEvent(UUID, String?)
         case addToCalendarTapped
     }
-
+    
     // 상태변경 이벤트 정의 (상태를 어떻게 바꿀 것인가)
     enum Mutation {}
-
+    
     // View의 상태 정의 (현재 View의 상태값)
     struct State {
         let eventItem: EventItem
     }
-
+    
     // 생성자에서 초기 상태 설정
     let initialState: State
     
@@ -46,13 +46,13 @@ final class EventDetailReactor: BaseReactor {
     
     // DI
     @Dependency(\.calendarService) private var calendarService
-
+    
     private let disposeBag = DisposeBag()
     
     init(eventItem: EventItem) {
         initialState = State(eventItem: eventItem)
     }
-
+    
     // Action이 들어왔을 때 어떤 Mutation으로 바뀔지 정의
     // 사용자 입력 → 상태 변화 신호로 변환
     func mutate(action: Action) -> Observable<Mutation> {
@@ -60,9 +60,21 @@ final class EventDetailReactor: BaseReactor {
         case let .moveToEdit(item):
             steps.accept(AppStep.updateSchedule(item))
             return .empty()
-        case let .deleteEvent(eventId):
+        case let .deleteEvent(eventId, calendarId):
             @Dependency(\.swiftDataManager) var swiftDataManager
             swiftDataManager.deleteEvent(id: eventId)
+            
+            // 캘린더에도 삭제 반영
+            if let calendarId {
+                calendarService.delete(eventId: calendarId)
+                    .subscribe()
+                    .disposed(by: disposeBag)
+            }
+            
+            // 알림도 취소
+            @Dependency(\.notificationService) var notificationService
+            notificationService.cancelNotification(id: eventId.uuidString)
+            
             steps.accept(AppStep.eventList)
             return .empty()
         case .addToCalendarTapped:
@@ -90,7 +102,7 @@ final class EventDetailReactor: BaseReactor {
             return .empty()
         }
     }
-
+    
     // Mutation이 발생했을 때 상태(State)를 실제로 바꿈
     // 상태 변화 신호 → 실제 상태 반영
     func reduce(state: State, mutation: Mutation) -> State {

--- a/EventLogger/Scenes/EventDetail/EventDetailViewController.swift
+++ b/EventLogger/Scenes/EventDetail/EventDetailViewController.swift
@@ -159,11 +159,12 @@ class EventDetailViewController: BaseViewController<EventDetailReactor> {
             .disposed(by: disposeBag)
         
         infoItemView.addCalendarButton.rx.tap
+            .throttle(.seconds(1), scheduler: MainScheduler.instance)
             .map { EventDetailReactor.Action.addToCalendarTapped }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
-        // TODO: 버튼액션
+        
         infoItemView.findDirectionsButton.rx.tap
             .withUnretained(self)
             .bind { `self`, _ in

--- a/EventLogger/Scenes/EventDetail/EventDetailViewController.swift
+++ b/EventLogger/Scenes/EventDetail/EventDetailViewController.swift
@@ -152,7 +152,7 @@ class EventDetailViewController: BaseViewController<EventDetailReactor> {
             .flatMap { `self`, _ in
                 UIAlertController.rx.alert(on: self, title: "일정 삭제", message: "정말로 이 일정을 삭제하시겠습니까?", actions: [
                     .cancel("취소"),
-                    .destructive("삭제", payload: .deleteEvent(eventItem.id, eventItem.calendarEventId)),
+                    .destructive("삭제", payload: .deleteEvent(eventItem)),
                 ])
             }
             .bind(to: reactor.action)

--- a/EventLogger/Scenes/EventDetail/EventDetailViewController.swift
+++ b/EventLogger/Scenes/EventDetail/EventDetailViewController.swift
@@ -152,7 +152,7 @@ class EventDetailViewController: BaseViewController<EventDetailReactor> {
             .flatMap { `self`, _ in
                 UIAlertController.rx.alert(on: self, title: "일정 삭제", message: "정말로 이 일정을 삭제하시겠습니까?", actions: [
                     .cancel("취소"),
-                    .destructive("삭제", payload: .deleteEvent(eventItem.id)),
+                    .destructive("삭제", payload: .deleteEvent(eventItem.id, eventItem.calendarEventId)),
                 ])
             }
             .bind(to: reactor.action)

--- a/EventLogger/Scenes/EventList/EventListReactor.swift
+++ b/EventLogger/Scenes/EventList/EventListReactor.swift
@@ -44,7 +44,6 @@ final class EventListReactor: BaseReactor {
 
     // 생성자에서 초기 상태 설정
     let initialState: State
-    @Dependency(\.modelContext) var modelContext
     @Dependency(\.swiftDataManager) var swiftDataManager
 
     init() {

--- a/EventLogger/Scenes/Schedule/ScheduleReactor.swift
+++ b/EventLogger/Scenes/Schedule/ScheduleReactor.swift
@@ -129,9 +129,17 @@ final class ScheduleReactor: BaseReactor {
                     artists: payload.artists,
                     expense: payload.expense,
                     currency: payload.currency,
-                    memo: payload.memo
+                    memo: payload.memo,
+                    calendarEventId: oldItem.calendarEventId // 캘린더이벤트 id는 유지
                 )
                 swiftDataManager.updateEvent(id: updated.id, event: updated)
+                
+                if settingsService.autoSaveToCalendar {
+                    calendarService.update(eventItem: updated)
+                        .subscribe()
+                        .disposed(by: disposeBag)
+                }
+                
                 schedulePushNotificationIfNeeded(updated)
                 steps.accept(AppStep.eventList)
                 return .empty()

--- a/EventLogger/Util/CalendarService.swift
+++ b/EventLogger/Util/CalendarService.swift
@@ -16,13 +16,15 @@ protocol CalendarServicing {
     func requestAccess() -> Single<Bool>
     /// EventItem을 기본 캘린더에 저장
     func save(eventItem: EventItem) -> Single<String>
+    func update(eventItem: EventItem) -> Single<Void>
+    func delete(eventId: String) -> Single<Void>
 }
 
 // MARK: 구현
 
 final class CalendarService: CalendarServicing {
     private let store = EKEventStore()
-
+    
     // 권한 요청
     func requestAccess() -> Single<Bool> {
         return Single<Bool>.create { single in
@@ -31,15 +33,15 @@ final class CalendarService: CalendarServicing {
             case .fullAccess:
                 // 읽기/쓰기 모두 가능
                 single(.success(true))
-
+                
             case .writeOnly:
                 // "쓰기 전용" 권한. 이벤트 저장에는 충분하지만
                 // 읽기가 필요한 기능이 있다면 false를 반환하도록 정책 변경 필요
                 single(.success(true))
-
+                
             case .denied, .restricted:
                 single(.success(false))
-
+                
             case .notDetermined:
                 Task {
                     do {
@@ -50,28 +52,28 @@ final class CalendarService: CalendarServicing {
                         single(.failure(error))
                     }
                 }
-
+                
             @unknown default:
                 single(.success(false))
             }
             return Disposables.create()
         }
     }
-
+    
     func save(eventItem: EventItem) -> Single<String> {
         return Single.create { [store] single in
             // 캘린더(기본 캘린더)에 이벤트 생성
             let event = EKEvent(eventStore: store)
             // TODO: identifer 활용한 리팩토링
-//            print(event.eventIdentifier)
+            //            print(event.eventIdentifier)
             event.calendar = store.defaultCalendarForNewEvents
-
+            
             event.title = eventItem.title
             event.startDate = eventItem.startTime
             event.endDate = eventItem.endTime
             event.location = eventItem.location
             event.notes = eventItem.memo
-
+            
             // 이미지/아티스트/통화 등은 EventKit에 직접 매핑할 필드가 없으므로 메모에 보조정보를 남기는 식으로
             if !eventItem.artists.isEmpty {
                 let artistsLine = "\n\n[출연자] " + eventItem.artists.joined(separator: ", ")
@@ -81,10 +83,64 @@ final class CalendarService: CalendarServicing {
                 let expenseLine = "\n[비용] \(eventItem.currency.rawValue) \(eventItem.expense)"
                 event.notes = (event.notes ?? "") + expenseLine
             }
-
+            
             do {
                 try store.save(event, span: .thisEvent, commit: true)
                 single(.success(event.eventIdentifier))
+            } catch {
+                single(.failure(error))
+            }
+            return Disposables.create()
+        }
+    }
+    
+    func update(eventItem: EventItem) -> Single<Void> {
+        // 1) identifier가 없으면 아직 달력에 없다고 판단하고 “넘김”
+        guard let id = eventItem.calendarEventId else { return .just(()) }
+        
+        return Single.create { [store] single in
+            // 2) 기존 이벤트 찾아서 필드만 갱신
+            guard let event = store.event(withIdentifier: id) else {
+                // 다음 단계에서: 못 찾는 경우 새로 만들고 id 갱신 처리 예정
+                single(.success(()))
+                return Disposables.create()
+            }
+            
+            event.title = eventItem.title
+            event.startDate = eventItem.startTime
+            event.endDate = eventItem.endTime
+            event.location = eventItem.location
+            event.notes = eventItem.memo
+            
+            if !eventItem.artists.isEmpty {
+                let artistsLine = "\n\n[출연자] " + eventItem.artists.joined(separator: ", ")
+                event.notes = (event.notes ?? "") + artistsLine
+            }
+            if eventItem.expense > 0 {
+                let expenseLine = "\n[비용] \(eventItem.currency.rawValue) \(eventItem.expense)"
+                event.notes = (event.notes ?? "") + expenseLine
+            }
+            
+            do {
+                try store.save(event, span: .thisEvent, commit: true)
+                single(.success(()))
+            } catch {
+                single(.failure(error))
+            }
+            return Disposables.create()
+        }
+    }
+    
+    func delete(eventId: String) -> Single<Void> {
+        return Single.create { [store] single in
+            guard let event = store.event(withIdentifier: eventId) else {
+                // 이미 사라진 경우로 간주 (성공 처리)
+                single(.success(()))
+                return Disposables.create()
+            }
+            do {
+                try store.remove(event, span: .thisEvent, commit: true)
+                single(.success(()))
             } catch {
                 single(.failure(error))
             }

--- a/EventLogger/Util/SwiftDataManger.swift
+++ b/EventLogger/Util/SwiftDataManger.swift
@@ -10,8 +10,10 @@ import Foundation
 import SwiftData
 import SwiftUI
 
+
 struct SwiftDataManager {
-    @Dependency(\.modelContext) var modelContext
+    
+    let modelContext = ModelContext(Persistence.container)
 
     // MARK: SaveContext
 


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #57 

<br>

### 🦁 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

캘린더 자동등록 옵션이 켜져있으면
이벤트 수정/삭제시에 기본 캘린더도 연동되어서 수정/삭제가 반영되게 수정하였습니다.

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->


<br>
