### PR TITLE
[Feat] #85 iOS 26 디자인 반영 안되게 info.plist 설정, 그외 기타 일정 리스트 뷰 수정

### DIFF
--- a/EventLogger/Resources/Info.plist
+++ b/EventLogger/Resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/EventLogger/Scenes/EventList/EventListContentViewController.swift
+++ b/EventLogger/Scenes/EventList/EventListContentViewController.swift
@@ -112,14 +112,21 @@ final class EventListContentViewController: BaseViewController<EventListReactor>
         view.backgroundColor = .clear
 
         view.addSubview(collectionView)
-        collectionView.snp.makeConstraints { $0.edges.equalToSuperview() }
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
 
-        collectionView.backgroundView = emptyView
+//        collectionView.backgroundView = emptyView
+        view.addSubview(emptyView)
+        emptyView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
         emptyView.addSubview(emptyStackView)
         emptyStackView.addArrangedSubview(emptyTitleLabel)
         emptyStackView.addArrangedSubview(emptyValueLabel)
         emptyStackView.snp.makeConstraints {
-            $0.center.equalToSuperview()
+            $0.directionalEdges.equalToSuperview()
         }
         emptyView.isHidden = true
     }
@@ -227,7 +234,7 @@ final class EventListContentViewController: BaseViewController<EventListReactor>
             let snapshot = self.dataSource.snapshot()
             let section = snapshot.sectionIdentifiers[indexPath.section]
             switch section {
-            case .nextUp: label.text = "다음 일정"
+            case .nextUp: label.text = "가장 가까운 일정"
             case let .month(ym): label.text = "\(ym.year)년 \(ym.month)월"
             }
         }
@@ -270,7 +277,7 @@ final class EventListContentViewController: BaseViewController<EventListReactor>
 
         let itemsByID = Dictionary(uniqueKeysWithValues: filtered.map { ($0.id, $0) })
 
-        // 3) 다음 일정
+        // 3) 가장 가까운 일정
         let nextUp: EventItem? = filtered
             .filter { $0.startTime >= today }
             .min(by: { $0.startTime < $1.startTime })
@@ -317,7 +324,7 @@ final class EventListContentViewController: BaseViewController<EventListReactor>
     ) {
         currentItemsByID = itemsByID
         dataSource.apply(snapshot, animatingDifferences: animated)
-        collectionView.backgroundView?.isHidden = !snapshot.itemIdentifiers.isEmpty
+        emptyView.isHidden = !snapshot.itemIdentifiers.isEmpty
     }
 
     // MARK: Helpers

--- a/EventLogger/Scenes/EventList/EventListPageContainerViewController.swift
+++ b/EventLogger/Scenes/EventList/EventListPageContainerViewController.swift
@@ -43,6 +43,7 @@ final class EventListPageContainerViewController: BaseViewController<EventListPa
     private let addButton = UIButton.makeAddButton()
 
     private let segmented = PillSegmentedControl(items: ["전체", "참여예정", "참여완료"]).then {
+        $0.backgroundColor = .appBackground
         $0.selectedIndex = 0
     }
 

--- a/EventLogger/Scenes/EventList/View/Cell/EventCell.swift
+++ b/EventLogger/Scenes/EventList/View/Cell/EventCell.swift
@@ -17,6 +17,10 @@ struct EventCell: View { // EventItem 통으로 받자
     let item: EventItem
     let category: CategoryItem
 
+    private var strokeColor: Color {
+        Color(UIColor.neutral50).opacity(0.40)
+    }
+
     var body: some View {
         HStack(alignment: .top, spacing: 14) {
             VStack(alignment: .leading, spacing: 0) {
@@ -76,7 +80,7 @@ struct EventCell: View { // EventItem 통으로 받자
         .cornerRadius(16)
         .overlay(
             RoundedRectangle(cornerRadius: 16)
-                .stroke(Color(UIColor.neutral50).opacity(0.40), lineWidth: 1)
+                .stroke(strokeColor, lineWidth: 1)
         )
     }
 }

--- a/EventLogger/Scenes/PillSegmentedControl.swift
+++ b/EventLogger/Scenes/PillSegmentedControl.swift
@@ -36,7 +36,6 @@ public final class PillSegmentedControl: UIControl {
         static let buttonContentInsets = NSDirectionalEdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12)
         static let minHeight: CGFloat = 50
         static let attachInset: CGFloat = 2
-        static let textShadowOpacity: Float = 1
         static let textShadowRadius: CGFloat = 7
         static let textShadowOffset: CGSize = .zero
     }
@@ -198,12 +197,9 @@ public final class PillSegmentedControl: UIControl {
 
     private func applyTextShadow(to label: UILabel, selected: Bool) {
         label.layer.masksToBounds = false
-        label.layer.shadowColor = Theme.shadowColor.cgColor
-        label.layer.shadowOpacity = selected ? Theme.textShadowOpacity : 0
+        label.shadowColor = selected ? Theme.shadowColor : nil
         label.layer.shadowRadius = Theme.textShadowRadius
-        label.layer.shadowOffset = Theme.textShadowOffset
-        label.layer.shouldRasterize = true
-        label.layer.rasterizationScale = UIScreen.main.scale
+        label.shadowOffset = Theme.textShadowOffset
     }
 }
 


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #1

<br>

### 🦁 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

iOS 26 디자인 반영 안되게 info.plist 설정, 그외 기타 일정 리스트 뷰 수정

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-16 at 16 34 41" src="https://github.com/user-attachments/assets/dc27bb4c-fe6e-448a-901a-2b90ec1e42b2" />

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->


<br>
